### PR TITLE
Class 14 pyramid template - Added tests

### DIFF
--- a/pyramid_stocks/pyramid_stocks/tests/tests.py
+++ b/pyramid_stocks/pyramid_stocks/tests/tests.py
@@ -1,5 +1,8 @@
 
 def test_default_behavior_of_home_view(dummy_request):
+    """
+    Tests default behavior of home view
+    """
     from ..views.default import home_view
 
     response = home_view(dummy_request)
@@ -8,6 +11,9 @@ def test_default_behavior_of_home_view(dummy_request):
 
 
 def test_default_behavior_of_auth_view(dummy_request):
+    """
+    Tests default behavior of auth view
+    """
     from ..views.default import auth_view
 
     response = auth_view(dummy_request)
@@ -16,6 +22,9 @@ def test_default_behavior_of_auth_view(dummy_request):
 
 
 def test_default_behavior_of_stock_view(dummy_request):
+    """
+    Tests default behavior of rendering a single stock
+    """
     from ..views.default import stock_view
 
     response = stock_view(dummy_request)
@@ -24,6 +33,9 @@ def test_default_behavior_of_stock_view(dummy_request):
 
 
 def test_default_behavior_of_portfolio_view(dummy_request):
+    """
+    Tests default behavior of portfolio endpoint
+    """
     from ..views.default import portfolio_view
 
     response = portfolio_view(dummy_request)
@@ -31,5 +43,19 @@ def test_default_behavior_of_portfolio_view(dummy_request):
     assert response['entries'][0]['symbol'] == 'GE'
 
 
+def test_default_behavior_of_portfolio_stock_view(dummy_request):
+    """
+    Tests default behavior of a single stock in the portfolio
+    """
+    from ..views.default import portfolio_stock_view
+
+    response = portfolio_stock_view(dummy_request)
+    assert type(response) == dict
+    assert response == {}
+
+
 def test_jeremy_is_awesome():
+    """
+    Tests a universal truth
+    """
     assert True

--- a/pyramid_stocks/pyramid_stocks/tests/tests.py
+++ b/pyramid_stocks/pyramid_stocks/tests/tests.py
@@ -1,4 +1,27 @@
 
+def test_default_behavior_of_home_view(dummy_request):
+    from ..views.default import home_view
+
+    response = home_view(dummy_request)
+    assert type(response) == dict
+    assert response == {}
+
+
+def test_default_behavior_of_auth_view(dummy_request):
+    from ..views.default import auth_view
+
+    response = auth_view(dummy_request)
+    assert type(response) == dict
+    assert response == {}
+
+
+def test_default_behavior_of_stock_view(dummy_request):
+    from ..views.default import stock_view
+
+    response = stock_view(dummy_request)
+    assert type(response) == dict
+    assert response == {}
+
 
 def test_default_behavior_of_portfolio_view(dummy_request):
     from ..views.default import portfolio_view

--- a/pyramid_stocks/pyramid_stocks/views/default.py
+++ b/pyramid_stocks/pyramid_stocks/views/default.py
@@ -1,5 +1,4 @@
 from pyramid.view import view_config
-# from pyramid.response import Response
 from ..sample_data import MOCK_DATA
 from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 
@@ -61,7 +60,11 @@ def portfolio_view(request):
     renderer='../templates/portfolio-detail.jinja2',
     request_method='GET')
 def portfolio_stock_view(request):
-    for entry in MOCK_DATA:
-        if entry['symbol'] == request.matchdict['symbol']:
-            return {'stock': entry}
+    try:
+        for entry in MOCK_DATA:
+            if entry['symbol'] == request.matchdict['symbol']:
+                return {'stock': entry}
+    
+    except KeyError:
+        return {}
 

--- a/pyramid_stocks/pyramid_stocks/views/default.py
+++ b/pyramid_stocks/pyramid_stocks/views/default.py
@@ -42,7 +42,7 @@ def auth_view(request):
     route_name='stock',
     renderer='../templates/stock-detail.jinja2',
     request_method='GET')
-def detail_view(request):
+def stock_view(request):
     return {}
 
 


### PR DESCRIPTION
Added more tests

Specifications
- [x] In your pyramid-stocks repository create a branch called class-14-pyramid-templating
- [x] Create a sample_data directory inside of your application's root. Within this directory, create an __init__.py file that defines a variable called MOCK_DATA.
- [x] MOCK_DATA will be a list of at least 10 dictionaries.
- [x] Each dictionary within the above list will be of the format:
- [x] Your Jinja2 templates should use template inheritance instead of repeating any of the site's layout
- [x] Your template's links to the app itself, the navigation items, should be done using request.route_url instead of being hardcoded
- [x] Your CSS, JavaScript, or image files that are stored in your static directory should be included with request.static_url instead of being hardcoded
- [x] Your /portfolio route should use a {% for %} loop to populate the stock list using the data in sample_data/__init__.py
- [x] Your /portfolio/{symbol} route should populate the data for the page based on the data from sample_data/__init__.py
- [x] /auth, when submitted, should redirect the user to the portfolio page. No need to worry about distinguishing your forms on the page at this point. POST /auth for your signup and GET /auth for your signin, are sufficient.
- [x] You do not need to collect the form data or authenticate the user, yet, rather just ensure that you are able to receive the request on the server, and redirect the client to the portfolio page.

Testing
- [x] Your tests don't need to cover all of Pyramid's functionality, as you didn't write Pyramid yourself. Your tests only need to cover the view functions that you wrote.
- [x] Write a series of tests which cover your view controllers and any other functionality that you've specifically defined within the scaffold. This should include only unit tests today.